### PR TITLE
Unit tests for interacting with ECR (Resolver and Fetcher)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -328,7 +328,10 @@
   branch = "master"
   digest = "1:964b5eed574102624d89e65d60548ea4873cbb02cff615a4f17bbb6cf337750a"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = ""
   revision = "34c6fa2dc70986bccbbffcc6130f6920a924b075"
 
@@ -477,6 +480,7 @@
     "github.com/opencontainers/image-spec/specs-go/v1",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "golang.org/x/net/context/ctxhttp",
     "golang.org/x/sync/errgroup",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,7 +70,6 @@
     "private/protocol/rest",
     "private/protocol/xml/xmlutil",
     "service/ecr",
-    "service/ecr/ecriface",
     "service/sts",
   ]
   pruneopts = ""
@@ -461,7 +460,6 @@
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ecr",
-    "github.com/aws/aws-sdk-go/service/ecr/ecriface",
     "github.com/containerd/containerd",
     "github.com/containerd/containerd/content",
     "github.com/containerd/containerd/errdefs",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -458,6 +458,7 @@
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/arn",
     "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/request",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ecr",
     "github.com/containerd/containerd",

--- a/ecr/base.go
+++ b/ecr/base.go
@@ -53,9 +53,10 @@ func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {
 	imageIdentifier := b.ecrSpec.ImageID()
 	log.G(ctx).WithField("imageIdentifier", imageIdentifier).Debug("ecr.base.manifest")
 	batchGetImageInput := &ecr.BatchGetImageInput{
-		RegistryId:         aws.String(b.ecrSpec.Registry()),
-		RepositoryName:     aws.String(b.ecrSpec.Repository),
-		ImageIds:           []*ecr.ImageIdentifier{imageIdentifier},
+		RegistryId:     aws.String(b.ecrSpec.Registry()),
+		RepositoryName: aws.String(b.ecrSpec.Repository),
+		ImageIds:       []*ecr.ImageIdentifier{imageIdentifier},
+		// TODO: Determine if this should be hard-coded
 		AcceptedMediaTypes: []*string{aws.String(images.MediaTypeDockerSchema2Manifest)},
 	}
 

--- a/ecr/base.go
+++ b/ecr/base.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You
  * may not use this file except in compliance with the License. A copy of
@@ -21,7 +21,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
-	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
@@ -32,8 +31,21 @@ var (
 )
 
 type ecrBase struct {
-	client  ecriface.ECRAPI
+	client  ecrAPI
 	ecrSpec ECRSpec
+}
+
+// ecrAPI contains only the ECR APIs that are called by the resolver
+// See https://docs.aws.amazon.com/sdk-for-go/api/service/ecr/ecriface/ for the
+// full interface from the SDK.
+type ecrAPI interface {
+	BatchGetImage(*ecr.BatchGetImageInput) (*ecr.BatchGetImageOutput, error)
+	GetDownloadUrlForLayer(*ecr.GetDownloadUrlForLayerInput) (*ecr.GetDownloadUrlForLayerOutput, error)
+	BatchCheckLayerAvailability(*ecr.BatchCheckLayerAvailabilityInput) (*ecr.BatchCheckLayerAvailabilityOutput, error)
+	InitiateLayerUpload(*ecr.InitiateLayerUploadInput) (*ecr.InitiateLayerUploadOutput, error)
+	UploadLayerPart(*ecr.UploadLayerPartInput) (*ecr.UploadLayerPartOutput, error)
+	CompleteLayerUpload(*ecr.CompleteLayerUploadInput) (*ecr.CompleteLayerUploadOutput, error)
+	PutImage(*ecr.PutImageInput) (*ecr.PutImageOutput, error)
 }
 
 func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {

--- a/ecr/base.go
+++ b/ecr/base.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -39,13 +40,13 @@ type ecrBase struct {
 // See https://docs.aws.amazon.com/sdk-for-go/api/service/ecr/ecriface/ for the
 // full interface from the SDK.
 type ecrAPI interface {
-	BatchGetImage(*ecr.BatchGetImageInput) (*ecr.BatchGetImageOutput, error)
-	GetDownloadUrlForLayer(*ecr.GetDownloadUrlForLayerInput) (*ecr.GetDownloadUrlForLayerOutput, error)
-	BatchCheckLayerAvailability(*ecr.BatchCheckLayerAvailabilityInput) (*ecr.BatchCheckLayerAvailabilityOutput, error)
+	BatchGetImageWithContext(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error)
+	GetDownloadUrlForLayerWithContext(aws.Context, *ecr.GetDownloadUrlForLayerInput, ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error)
+	BatchCheckLayerAvailabilityWithContext(aws.Context, *ecr.BatchCheckLayerAvailabilityInput, ...request.Option) (*ecr.BatchCheckLayerAvailabilityOutput, error)
 	InitiateLayerUpload(*ecr.InitiateLayerUploadInput) (*ecr.InitiateLayerUploadOutput, error)
 	UploadLayerPart(*ecr.UploadLayerPartInput) (*ecr.UploadLayerPartOutput, error)
 	CompleteLayerUpload(*ecr.CompleteLayerUploadInput) (*ecr.CompleteLayerUploadOutput, error)
-	PutImage(*ecr.PutImageInput) (*ecr.PutImageOutput, error)
+	PutImageWithContext(aws.Context, *ecr.PutImageInput, ...request.Option) (*ecr.PutImageOutput, error)
 }
 
 func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {
@@ -58,7 +59,7 @@ func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {
 		AcceptedMediaTypes: []*string{aws.String(images.MediaTypeDockerSchema2Manifest)},
 	}
 
-	batchGetImageOutput, err := b.client.BatchGetImage(batchGetImageInput)
+	batchGetImageOutput, err := b.client.BatchGetImageWithContext(ctx, batchGetImageInput)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("ecr.base.manifest: failed to get image")
 		fmt.Println(err)

--- a/ecr/fake_ecr_client_test.go
+++ b/ecr/fake_ecr_client_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package ecr
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecr"
+)
+
+// fakeECRClient is a fake that can be used for testing the ecrAPI interface.
+// Each method is backed by a function contained in the struct.  Nil functions
+// will cause panics when invoked.
+type fakeECRClient struct {
+	BatchGetImageFn               func(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error)
+	GetDownloadUrlForLayerFn      func(aws.Context, *ecr.GetDownloadUrlForLayerInput, ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error)
+	BatchCheckLayerAvailabilityFn func(aws.Context, *ecr.BatchCheckLayerAvailabilityInput, ...request.Option) (*ecr.BatchCheckLayerAvailabilityOutput, error)
+	InitiateLayerUploadFn         func(*ecr.InitiateLayerUploadInput) (*ecr.InitiateLayerUploadOutput, error)
+	UploadLayerPartFn             func(*ecr.UploadLayerPartInput) (*ecr.UploadLayerPartOutput, error)
+	CompleteLayerUploadFn         func(*ecr.CompleteLayerUploadInput) (*ecr.CompleteLayerUploadOutput, error)
+	PutImageFn                    func(aws.Context, *ecr.PutImageInput, ...request.Option) (*ecr.PutImageOutput, error)
+}
+
+var _ ecrAPI = (*fakeECRClient)(nil)
+
+func (f *fakeECRClient) BatchGetImageWithContext(ctx aws.Context, arg *ecr.BatchGetImageInput, opts ...request.Option) (*ecr.BatchGetImageOutput, error) {
+	return f.BatchGetImageFn(ctx, arg, opts...)
+}
+
+func (f *fakeECRClient) GetDownloadUrlForLayerWithContext(ctx aws.Context, arg *ecr.GetDownloadUrlForLayerInput, opts ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error) {
+	return f.GetDownloadUrlForLayerFn(ctx, arg, opts...)
+}
+
+func (f *fakeECRClient) BatchCheckLayerAvailabilityWithContext(ctx aws.Context, arg *ecr.BatchCheckLayerAvailabilityInput, opts ...request.Option) (*ecr.BatchCheckLayerAvailabilityOutput, error) {
+	return f.BatchCheckLayerAvailabilityFn(ctx, arg, opts...)
+}
+
+func (f *fakeECRClient) InitiateLayerUpload(arg *ecr.InitiateLayerUploadInput) (*ecr.InitiateLayerUploadOutput, error) {
+	return f.InitiateLayerUploadFn(arg)
+}
+
+func (f *fakeECRClient) UploadLayerPart(arg *ecr.UploadLayerPartInput) (*ecr.UploadLayerPartOutput, error) {
+	return f.UploadLayerPartFn(arg)
+}
+
+func (f *fakeECRClient) CompleteLayerUpload(arg *ecr.CompleteLayerUploadInput) (*ecr.CompleteLayerUploadOutput, error) {
+	return f.CompleteLayerUploadFn(arg)
+}
+
+func (f *fakeECRClient) PutImageWithContext(ctx aws.Context, arg *ecr.PutImageInput, opts ...request.Option) (*ecr.PutImageOutput, error) {
+	return f.PutImageFn(ctx, arg, opts...)
+}

--- a/ecr/fetcher.go
+++ b/ecr/fetcher.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You
  * may not use this file except in compliance with the License. A copy of
@@ -59,7 +59,8 @@ func (f *ecrFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.Rea
 		ocispec.MediaTypeImageLayer,
 		ocispec.MediaTypeImageConfig:
 		return f.fetchLayer(ctx, desc)
-	case images.MediaTypeDockerSchema2LayerForeignGzip:
+	case images.MediaTypeDockerSchema2LayerForeign,
+		images.MediaTypeDockerSchema2LayerForeignGzip:
 		return f.fetchForeignLayer(ctx, desc)
 	default:
 		log.G(ctx).

--- a/ecr/fetcher.go
+++ b/ecr/fetcher.go
@@ -88,7 +88,7 @@ func (f *ecrFetcher) fetchLayer(ctx context.Context, desc ocispec.Descriptor) (i
 		RepositoryName: aws.String(f.ecrSpec.Repository),
 		LayerDigest:    aws.String(desc.Digest.String()),
 	}
-	output, err := f.client.GetDownloadUrlForLayer(getDownloadUrlForLayerInput)
+	output, err := f.client.GetDownloadUrlForLayerWithContext(ctx, getDownloadUrlForLayerInput)
 	if err != nil {
 		return nil, err
 	}

--- a/ecr/fetcher_test.go
+++ b/ecr/fetcher_test.go
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package ecr
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchUnimplemented(t *testing.T) {
+	fetcher := &ecrFetcher{}
+	desc := ocispec.Descriptor{
+		MediaType: "never-implemented",
+	}
+	_, err := fetcher.Fetch(context.Background(), desc)
+	assert.EqualError(t, err, unimplemented.Error())
+}
+
+func TestFetchForeignLayer(t *testing.T) {
+	// setup
+	expectedBody := "hello this is dog"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expectedBody)
+	}))
+	defer ts.Close()
+
+	fetcher := &ecrFetcher{}
+
+	// test both media types
+	for _, mediaType := range []string{
+		images.MediaTypeDockerSchema2LayerForeign,
+		images.MediaTypeDockerSchema2LayerForeignGzip,
+	} {
+		t.Run(mediaType, func(t *testing.T) {
+			// input
+			desc := ocispec.Descriptor{
+				MediaType: mediaType,
+				URLs:      []string{ts.URL},
+			}
+
+			reader, err := fetcher.Fetch(context.Background(), desc)
+			require.NoError(t, err, "fetch should succeed from test server")
+			defer reader.Close()
+
+			output, err := ioutil.ReadAll(reader)
+			assert.NoError(t, err, "should have a valid byte buffer")
+			assert.Equal(t, expectedBody, string(output))
+		})
+	}
+}
+
+func TestFetchForeignLayerNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	fetcher := &ecrFetcher{}
+	mediaType := images.MediaTypeDockerSchema2LayerForeignGzip
+
+	desc := ocispec.Descriptor{
+		MediaType: mediaType,
+		URLs:      []string{ts.URL},
+	}
+
+	_, err := fetcher.Fetch(context.Background(), desc)
+	assert.Error(t, err)
+	cause := errors.Cause(err)
+	assert.Equal(t, errdefs.ErrNotFound, cause)
+}
+
+func TestFetchManifest(t *testing.T) {
+	registry := "registry"
+	repository := "repository"
+	imageTag := "tag"
+	imageManifest := "image manifest"
+	fakeClient := &fakeECRClient{}
+	fetcher := &ecrFetcher{
+		ecrBase{
+			client: fakeClient,
+			ecrSpec: ECRSpec{
+				arn: arn.ARN{
+					AccountID: registry,
+				},
+				Repository: repository,
+				Object:     imageTag,
+			},
+		},
+	}
+
+	// test all supported media types
+	for _, mediaType := range []string{
+		ocispec.MediaTypeImageManifest,
+		images.MediaTypeDockerSchema2Manifest,
+		images.MediaTypeDockerSchema1Manifest,
+	} {
+		t.Run(mediaType, func(t *testing.T) {
+			callCount := 0
+			fakeClient.BatchGetImageFn = func(_ aws.Context, input *ecr.BatchGetImageInput, _ ...request.Option) (*ecr.BatchGetImageOutput, error) {
+				callCount++
+				assert.Equal(t, registry, aws.StringValue(input.RegistryId))
+				assert.Equal(t, repository, aws.StringValue(input.RepositoryName))
+				assert.Equal(t, []*ecr.ImageIdentifier{{ImageTag: aws.String(imageTag)}}, input.ImageIds)
+				// TODO: Determine if we should be matching the requested media type from containerd
+				assert.Equal(t, []*string{aws.String(images.MediaTypeDockerSchema2Manifest)}, input.AcceptedMediaTypes)
+				return &ecr.BatchGetImageOutput{Images: []*ecr.Image{{ImageManifest: aws.String(imageManifest)}}}, nil
+			}
+			desc := ocispec.Descriptor{
+				MediaType: mediaType,
+			}
+			reader, err := fetcher.Fetch(context.Background(), desc)
+			assert.NoError(t, err, "fetch")
+			defer reader.Close()
+			assert.Equal(t, 1, callCount, "BatchGetImage should be called once")
+			manifest, err := ioutil.ReadAll(reader)
+			assert.NoError(t, err, "reading manifest")
+			assert.Equal(t, imageManifest, string(manifest))
+		})
+	}
+}
+
+func TestFetchManifestAPIError(t *testing.T) {
+	ref := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest"
+	mediaType := ocispec.MediaTypeImageManifest
+
+	fakeClient := &fakeECRClient{
+		BatchGetImageFn: func(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error) {
+			return nil, errors.New("expected")
+		},
+	}
+	resolver := &ecrResolver{
+		clients: map[string]ecrAPI{
+			"fake": fakeClient,
+		},
+	}
+	fetcher, err := resolver.Fetcher(context.Background(), ref)
+	require.NoError(t, err, "failed to create fetcher")
+	_, err = fetcher.Fetch(context.Background(), ocispec.Descriptor{MediaType: mediaType})
+	assert.EqualError(t, err, "expected")
+}
+
+func TestFetchManifestNotFound(t *testing.T) {
+	ref := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest"
+	mediaType := ocispec.MediaTypeImageManifest
+
+	fakeClient := &fakeECRClient{
+		BatchGetImageFn: func(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error) {
+			return &ecr.BatchGetImageOutput{
+				Failures: []*ecr.ImageFailure{
+					{FailureCode: aws.String(ecr.ImageFailureCodeImageNotFound)},
+				},
+			}, nil
+		},
+	}
+	resolver := &ecrResolver{
+		clients: map[string]ecrAPI{
+			"fake": fakeClient,
+		},
+	}
+	fetcher, err := resolver.Fetcher(context.Background(), ref)
+	require.NoError(t, err, "failed to create fetcher")
+	_, err = fetcher.Fetch(context.Background(), ocispec.Descriptor{MediaType: mediaType})
+	assert.Error(t, err)
+}
+
+func TestFetchLayer(t *testing.T) {
+	registry := "registry"
+	repository := "repository"
+	layerDigest := "digest"
+	fakeClient := &fakeECRClient{}
+	fetcher := &ecrFetcher{
+		ecrBase{
+			client: fakeClient,
+			ecrSpec: ECRSpec{
+				arn: arn.ARN{
+					AccountID: registry,
+				},
+				Repository: repository,
+			},
+		},
+	}
+	expectedBody := "hello this is dog"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expectedBody)
+	}))
+	defer ts.Close()
+
+	// test all supported media types
+	for _, mediaType := range []string{
+		images.MediaTypeDockerSchema2Layer,
+		images.MediaTypeDockerSchema2LayerGzip,
+		images.MediaTypeDockerSchema2Config,
+		ocispec.MediaTypeImageLayerGzip,
+		ocispec.MediaTypeImageLayer,
+		ocispec.MediaTypeImageConfig,
+	} {
+		t.Run(mediaType, func(t *testing.T) {
+			callCount := 0
+			fakeClient.GetDownloadUrlForLayerFn = func(_ aws.Context, input *ecr.GetDownloadUrlForLayerInput, _ ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error) {
+				callCount++
+				assert.Equal(t, registry, aws.StringValue(input.RegistryId))
+				assert.Equal(t, repository, aws.StringValue(input.RepositoryName))
+				assert.Equal(t, layerDigest, aws.StringValue(input.LayerDigest))
+				return &ecr.GetDownloadUrlForLayerOutput{DownloadUrl: aws.String(ts.URL)}, nil
+			}
+			desc := ocispec.Descriptor{
+				MediaType: mediaType,
+				Digest:    digest.Digest(layerDigest),
+			}
+			reader, err := fetcher.Fetch(context.Background(), desc)
+			assert.NoError(t, err, "fetch")
+			defer reader.Close()
+			assert.Equal(t, 1, callCount, "GetDownloadURLForLayer should be called once")
+			body, err := ioutil.ReadAll(reader)
+			assert.NoError(t, err, "reading body")
+			assert.Equal(t, expectedBody, string(body))
+		})
+	}
+}
+
+func TestFetchLayerAPIError(t *testing.T) {
+	fakeClient := &fakeECRClient{
+		GetDownloadUrlForLayerFn: func(aws.Context, *ecr.GetDownloadUrlForLayerInput, ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error) {
+			return nil, errors.New("expected")
+		},
+	}
+	fetcher := &ecrFetcher{
+		ecrBase{
+			client: fakeClient,
+		},
+	}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayerGzip,
+	}
+	_, err := fetcher.Fetch(context.Background(), desc)
+	assert.Error(t, err)
+}

--- a/ecr/manifest_writer.go
+++ b/ecr/manifest_writer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You
  * may not use this file except in compliance with the License. A copy of
@@ -66,7 +66,7 @@ func (mw *manifestWriter) Commit(ctx context.Context, size int64, expected diges
 		ImageManifest:  aws.String(manifest),
 	}
 
-	output, err := mw.base.client.PutImage(putImageInput)
+	output, err := mw.base.client.PutImageWithContext(ctx, putImageInput)
 	if err != nil {
 		return errors.Wrapf(err, "ecr: failed to put manifest: %v", ecrSpec)
 	}

--- a/ecr/pusher.go
+++ b/ecr/pusher.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You
  * may not use this file except in compliance with the License. A copy of
@@ -126,7 +126,7 @@ func (p ecrPusher) checkBlobExistence(ctx context.Context, desc ocispec.Descript
 		LayerDigests:   []*string{aws.String(desc.Digest.String())},
 	}
 
-	batchCheckLayerAvailabilityOutput, err := p.client.BatchCheckLayerAvailability(batchCheckLayerAvailabilityInput)
+	batchCheckLayerAvailabilityOutput, err := p.client.BatchCheckLayerAvailabilityWithContext(ctx, batchCheckLayerAvailabilityInput)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("ecr.pusher.blob: failed to check availability")
 		return false, err

--- a/ecr/resolver.go
+++ b/ecr/resolver.go
@@ -78,7 +78,7 @@ func (r *ecrResolver) Resolve(ctx context.Context, ref string) (string, ocispec.
 
 	client := r.getClient(ecrSpec.Region())
 
-	batchGetImageOutput, err := client.BatchGetImage(batchGetImageInput)
+	batchGetImageOutput, err := client.BatchGetImageWithContext(ctx, batchGetImageInput)
 	if err != nil {
 		log.G(ctx).
 			WithField("ref", ref).

--- a/ecr/resolver.go
+++ b/ecr/resolver.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You
  * may not use this file except in compliance with the License. A copy of
@@ -25,13 +25,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	ecrsdk "github.com/aws/aws-sdk-go/service/ecr"
-	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -39,7 +38,7 @@ var unimplemented = errors.New("unimplemented")
 
 type ecrResolver struct {
 	session     *session.Session
-	clients     map[string]ecriface.ECRAPI
+	clients     map[string]ecrAPI
 	clientsLock sync.Mutex
 	tracker     docker.StatusTracker
 }
@@ -55,7 +54,7 @@ func NewResolver(session *session.Session, options ResolverOptions) remotes.Reso
 	}
 	return &ecrResolver{
 		session: session,
-		clients: map[string]ecriface.ECRAPI{},
+		clients: map[string]ecrAPI{},
 		tracker: options.Tracker,
 	}
 }
@@ -111,7 +110,7 @@ func (r *ecrResolver) Resolve(ctx context.Context, ref string) (string, ocispec.
 	return ecrSpec.Canonical(), desc, nil
 }
 
-func (r *ecrResolver) getClient(region string) ecriface.ECRAPI {
+func (r *ecrResolver) getClient(region string) ecrAPI {
 	r.clientsLock.Lock()
 	defer r.clientsLock.Unlock()
 	if _, ok := r.clients[region]; !ok {

--- a/ecr/resolver_test.go
+++ b/ecr/resolver_test.go
@@ -1,10 +1,30 @@
+/*
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ * 	http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
 package ecr
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/reference"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,4 +67,98 @@ func TestParseImageManifestMediaType(t *testing.T) {
 			assert.Equal(t, tc.mediaType, mediaType)
 		})
 	}
+}
+
+func TestResolve(t *testing.T) {
+	// input
+	expectedRef := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest"
+
+	// expected API arguments
+	expectedRegistryID := "123456789012"
+	expectedRepository := "foo/bar"
+	expectedImageTag := "latest"
+
+	// API output
+	imageDigest := "sha256:digest"
+	imageManifest := `{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json"}`
+	image := &ecr.Image{
+		RepositoryName: aws.String(expectedRepository),
+		ImageId: &ecr.ImageIdentifier{
+			ImageDigest: aws.String(imageDigest),
+		},
+		ImageManifest: aws.String(imageManifest),
+	}
+
+	// expected output
+	expectedDesc := ocispec.Descriptor{
+		Digest:    digest.Digest(imageDigest),
+		MediaType: ocispec.MediaTypeImageManifest,
+		Size:      int64(len(imageManifest)),
+	}
+
+	fakeClient := &fakeECRClient{
+		BatchGetImageFn: func(ctx aws.Context, input *ecr.BatchGetImageInput, opts ...request.Option) (*ecr.BatchGetImageOutput, error) {
+			assert.Equal(t, expectedRegistryID, aws.StringValue(input.RegistryId))
+			assert.Equal(t, expectedRepository, aws.StringValue(input.RepositoryName))
+			assert.Equal(t, []*ecr.ImageIdentifier{{ImageTag: aws.String(expectedImageTag)}}, input.ImageIds)
+			return &ecr.BatchGetImageOutput{Images: []*ecr.Image{image}}, nil
+		},
+	}
+	resolver := &ecrResolver{
+		clients: map[string]ecrAPI{
+			"fake": fakeClient,
+		},
+	}
+
+	ref, desc, err := resolver.Resolve(context.Background(), expectedRef)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRef, ref)
+	assert.Equal(t, expectedDesc, desc)
+}
+
+func TestResolveError(t *testing.T) {
+	// input
+	ref := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest"
+
+	// expected output
+	expectedError := errors.New("expected")
+
+	fakeClient := &fakeECRClient{
+		BatchGetImageFn: func(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error) {
+			return nil, expectedError
+		},
+	}
+	resolver := &ecrResolver{
+		clients: map[string]ecrAPI{
+			"fake": fakeClient,
+		},
+	}
+	_, _, err := resolver.Resolve(context.Background(), ref)
+	assert.EqualError(t, err, expectedError.Error())
+}
+
+func TestResolveNoResult(t *testing.T) {
+	// input
+	ref := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest"
+
+	fakeClient := &fakeECRClient{
+		BatchGetImageFn: func(aws.Context, *ecr.BatchGetImageInput, ...request.Option) (*ecr.BatchGetImageOutput, error) {
+			return &ecr.BatchGetImageOutput{}, nil
+		},
+	}
+	resolver := &ecrResolver{
+		clients: map[string]ecrAPI{
+			"fake": fakeClient,
+		},
+	}
+	_, _, err := resolver.Resolve(context.Background(), ref)
+	assert.Error(t, err)
+	assert.Equal(t, reference.ErrInvalid, err)
+}
+
+func TestResolvePusherDenyDigest(t *testing.T) {
+	ref := "ecr.aws/arn:aws:ecr:fake:123456789012:repository/foo/bar:latest@sha256:digest"
+	resolver := &ecrResolver{}
+	_, err := resolver.Pusher(context.Background(), ref)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Add a bunch of unit tests covering interactions with ECR.  There's a lot here, but each commit should stand on its own and can be reviewed in sequence.

This PR currently covers the Resolver and Fetcher, but not the Pusher.  It can be reviewed now and Pusher tests can be submitted separately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
