### PR TITLE
Fix error handling for digests with multiple tags

### DIFF
--- a/ecr/base.go
+++ b/ecr/base.go
@@ -69,7 +69,7 @@ func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {
 	log.G(ctx).WithField("batchGetImage", batchGetImageOutput).Debug("ecr.base.manifest")
 
 	var ecrImage *ecr.Image
-	if len(batchGetImageOutput.Images) != 1 {
+	if len(batchGetImageOutput.Images) == 0 {
 		if len(batchGetImageOutput.Failures) > 0 &&
 			aws.StringValue(batchGetImageOutput.Failures[0].FailureCode) == ecr.ImageFailureCodeImageNotFound {
 			return nil, errImageNotFound

--- a/ecr/pusher.go
+++ b/ecr/pusher.go
@@ -135,7 +135,7 @@ func (p ecrPusher) checkBlobExistence(ctx context.Context, desc ocispec.Descript
 		WithField("batchCheckLayerAvailability", batchCheckLayerAvailabilityOutput).
 		Debug("ecr.pusher.blob")
 
-	if len(batchCheckLayerAvailabilityOutput.Layers) != 1 {
+	if len(batchCheckLayerAvailabilityOutput.Layers) == 0 {
 		if len(batchCheckLayerAvailabilityOutput.Failures) > 0 {
 			return false, errLayerNotFound
 		}

--- a/ecr/resolver.go
+++ b/ecr/resolver.go
@@ -92,7 +92,7 @@ func (r *ecrResolver) Resolve(ctx context.Context, ref string) (string, ocispec.
 		Debug("ecr.resolver.resolve")
 
 	var ecrImage *ecr.Image
-	if len(batchGetImageOutput.Images) != 1 {
+	if len(batchGetImageOutput.Images) == 0 {
 		return "", ocispec.Descriptor{}, reference.ErrInvalid
 	}
 	ecrImage = batchGetImageOutput.Images[0]


### PR DESCRIPTION
*Description of changes:*
Some manifests have multiple tags. When pulling by digest, we should fail if there are no images, not if there is not 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
