### PR TITLE
resolver: use functional options for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Registry API.
 
 ### Pull images
 ```go
+resolver, _ := ecr.NewResolver()
 img, err := client.Pull(
     namespaces.NamespaceFromEnv(context.TODO()),
     "ecr.aws/arn:aws:ecr:us-west-2:123456789012:repository/myrepository:mytag",
-    containerd.WithResolver(ecr.NewResolver(awsSession)),
+    containerd.WithResolver(resolver),
     containerd.WithPullUnpack,
     containerd.WithSchema1Conversion)
 ```
@@ -30,12 +31,12 @@ ctx := namespaces.NamsepaceFromEnv(context.TODO())
 img, _ := client.ImageService().Get(
 	ctx,
 	"docker.io/library/busybox:latest")
-
+resolver, _ := ecr.NewResolver()
 err = client.Push(
 	ctx,
 	"ecr.aws/arn:aws:ecr:us-west-2:123456789012:repository/myrepository:mytag",
 	img.Target,
-	containerd.WithResolver(ecr.NewResolver(awsSession)))
+	containerd.WithResolver(resolver))
 ```
 
 Two small example programs are provided in the [example](tree/master/example)

--- a/example/ecr-copy/main.go
+++ b/example/ecr-copy/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
@@ -41,11 +40,10 @@ func main() {
 	}
 	defer client.Close()
 
-	awsSession, err := session.NewSession()
+	resolver, err := ecr.NewResolver()
 	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create AWS session")
+		log.G(ctx).WithError(err).Fatal("Failed to create resolver")
 	}
-	resolver := ecr.NewResolver(awsSession, ecr.ResolverOptions{})
 
 	log.G(ctx).WithField("sourceRef", sourceRef).Info("Pulling from Amazon ECR")
 	img, err := client.Pull(

--- a/example/ecr-pull/main.go
+++ b/example/ecr-pull/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -41,11 +40,6 @@ func main() {
 	}
 	defer client.Close()
 
-	awsSession, err := session.NewSession()
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create AWS session")
-	}
-
 	ongoing := newJobs(ref)
 	pctx, stopProgress := context.WithCancel(ctx)
 	progress := make(chan struct{})
@@ -61,9 +55,14 @@ func main() {
 		return nil, nil
 	})
 
+	resolver, err := ecr.NewResolver()
+	if err != nil {
+		log.G(ctx).WithError(err).Fatal("Failed to create resolver")
+	}
+
 	log.G(ctx).WithField("ref", ref).Info("Pulling from Amazon ECR")
 	img, err := client.Pull(ctx, ref,
-		containerd.WithResolver(ecr.NewResolver(awsSession, ecr.ResolverOptions{})),
+		containerd.WithResolver(resolver),
 		containerd.WithImageHandler(h),
 		containerd.WithSchema1Conversion)
 	stopProgress()

--- a/example/ecr-push/main.go
+++ b/example/ecr-push/main.go
@@ -21,7 +21,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -55,12 +54,11 @@ func main() {
 	}
 	defer client.Close()
 
-	awsSession, err := session.NewSession()
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create AWS session")
-	}
 	tracker := docker.NewInMemoryTracker()
-	resolver := ecr.NewResolver(awsSession, ecr.ResolverOptions{Tracker: tracker})
+	resolver, err := ecr.NewResolver(ecr.WithTracker(tracker))
+	if err != nil {
+		log.G(ctx).WithError(err).Fatal("Failed to create resolver")
+	}
 
 	img, err := client.ImageService().Get(ctx, local)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/samuelkarp/amazon-ecr-containerd-resolver/issues/9

*Description of changes:*
Move the `ecr.NewResolver` function to use functional options for `ecr.ResolverOptions`

cc @sipsma @xibz @aaithal @jmillikin-stripe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
