### PR TITLE
resolver: add OCI image manifest to media types

### DIFF
--- a/ecr/base.go
+++ b/ecr/base.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
@@ -58,7 +59,10 @@ func (b *ecrBase) getManifest(ctx context.Context) (*ecr.Image, error) {
 		RepositoryName: aws.String(b.ecrSpec.Repository),
 		ImageIds:       []*ecr.ImageIdentifier{imageIdentifier},
 		// TODO: Determine if this should be hard-coded
-		AcceptedMediaTypes: []*string{aws.String(images.MediaTypeDockerSchema2Manifest)},
+		AcceptedMediaTypes: []*string{
+			aws.String(ocispec.MediaTypeImageManifest),
+			aws.String(images.MediaTypeDockerSchema2Manifest),
+		},
 	}
 
 	batchGetImageOutput, err := b.client.BatchGetImageWithContext(ctx, batchGetImageInput)

--- a/ecr/fetcher_test.go
+++ b/ecr/fetcher_test.go
@@ -129,7 +129,10 @@ func TestFetchManifest(t *testing.T) {
 				assert.Equal(t, repository, aws.StringValue(input.RepositoryName))
 				assert.Equal(t, []*ecr.ImageIdentifier{{ImageTag: aws.String(imageTag)}}, input.ImageIds)
 				// TODO: Determine if we should be matching the requested media type from containerd
-				assert.Equal(t, []*string{aws.String(images.MediaTypeDockerSchema2Manifest)}, input.AcceptedMediaTypes)
+				assert.Equal(t, []*string{
+					aws.String(ocispec.MediaTypeImageManifest),
+					aws.String(images.MediaTypeDockerSchema2Manifest),
+				}, input.AcceptedMediaTypes)
 				return &ecr.BatchGetImageOutput{Images: []*ecr.Image{{ImageManifest: aws.String(imageManifest)}}}, nil
 			}
 			desc := ocispec.Descriptor{

--- a/ecr/pusher_test.go
+++ b/ecr/pusher_test.go
@@ -69,7 +69,10 @@ func TestPushManifestReturnsManifestWriter(t *testing.T) {
 				assert.Equal(t, repository, aws.StringValue(input.RepositoryName))
 				assert.Equal(t, []*ecr.ImageIdentifier{{ImageTag: aws.String(imageTag)}}, input.ImageIds)
 				// TODO: Determine if we should be matching the requested media type from containerd
-				assert.Equal(t, []*string{aws.String(images.MediaTypeDockerSchema2Manifest)}, input.AcceptedMediaTypes)
+				assert.Equal(t, []*string{
+					aws.String(ocispec.MediaTypeImageManifest),
+					aws.String(images.MediaTypeDockerSchema2Manifest),
+				}, input.AcceptedMediaTypes)
 				return &ecr.BatchGetImageOutput{
 					Failures: []*ecr.ImageFailure{
 						{FailureCode: aws.String(ecr.ImageFailureCodeImageNotFound)},

--- a/ecr/resolver.go
+++ b/ecr/resolver.go
@@ -119,10 +119,13 @@ func (r *ecrResolver) Resolve(ctx context.Context, ref string) (string, ocispec.
 	}
 
 	batchGetImageInput := &ecr.BatchGetImageInput{
-		RegistryId:         aws.String(ecrSpec.Registry()),
-		RepositoryName:     aws.String(ecrSpec.Repository),
-		ImageIds:           []*ecr.ImageIdentifier{ecrSpec.ImageID()},
-		AcceptedMediaTypes: []*string{aws.String(images.MediaTypeDockerSchema2Manifest)},
+		RegistryId:     aws.String(ecrSpec.Registry()),
+		RepositoryName: aws.String(ecrSpec.Repository),
+		ImageIds:       []*ecr.ImageIdentifier{ecrSpec.ImageID()},
+		AcceptedMediaTypes: []*string{
+			aws.String(ocispec.MediaTypeImageManifest),
+			aws.String(images.MediaTypeDockerSchema2Manifest),
+		},
 	}
 
 	client := r.getClient(ecrSpec.Region())


### PR DESCRIPTION
*Description of changes:*
This commit declares that the resolver can accept the "application/vnd.oci.image.manifest.v1+json" media type.

/cc @nmeyerhans @xibz @kzys

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
